### PR TITLE
Fix naming of metrics to remove service from name as the app name wil…

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -25,7 +25,7 @@ func NewMiddleware(name string, buckets ...float64) func(next http.Handler) http
 	var m Middleware
 	m.reqs = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name:        name + "_requests_total",
+			Name:        "http_requests_total",
 			Help:        "How many HTTP requests processed, partitioned by status code, method and HTTP path.",
 			ConstLabels: prometheus.Labels{"service": name},
 		},
@@ -37,7 +37,7 @@ func NewMiddleware(name string, buckets ...float64) func(next http.Handler) http
 		buckets = dflBuckets
 	}
 	m.latency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:        name + "_duration_milliseconds",
+		Name:        "http_request_duration_milliseconds",
 		Help:        "How long it took to process the request, partitioned by status code, method and HTTP path.",
 		ConstLabels: prometheus.Labels{"service": name},
 		Buckets:     buckets,


### PR DESCRIPTION
Rename our metrics to be consistent and remove the service name from the metric name as we push the app name and also have a service label - this allows us to use dashes as they are only excluded in prometheus metric names. 